### PR TITLE
Add support for substituting queryId in paths

### DIFF
--- a/src/openapi/paths/bookmarks.yaml
+++ b/src/openapi/paths/bookmarks.yaml
@@ -4,10 +4,12 @@ info:
   version: 0.0.1
 
 paths:
-  /graphql/{{queryId}}/Bookmarks:
+  /graphql/{queryId}/Bookmarks:
     get:
       operationId: getBookmarks
       description: get bookmarks
+      parameters:
+        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation

--- a/src/openapi/paths/follow.yaml
+++ b/src/openapi/paths/follow.yaml
@@ -4,10 +4,12 @@ info:
   version: 0.0.1
 
 paths:
-  /graphql/{{queryId}}/Following:
+  /graphql/{queryId}/Following:
     get:
       operationId: getFollowing
       description: get user list of following
+      parameters:
+        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation
@@ -18,10 +20,12 @@ paths:
       tags:
         - "user-list"
 
-  /graphql/{{queryId}}/Followers:
+  /graphql/{queryId}/Followers:
     get:
       operationId: getFollowers
       description: get user list of followers
+      parameters:
+        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation

--- a/src/openapi/paths/post.yaml
+++ b/src/openapi/paths/post.yaml
@@ -4,10 +4,12 @@ info:
   version: 0.0.1
 
 paths:
-  /graphql/{{queryId}}/FavoriteTweet:
+  /graphql/{queryId}/FavoriteTweet:
     post:
       operationId: postFavoriteTweet
       description: favorite Tweet
+      parameters:
+        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation
@@ -18,10 +20,12 @@ paths:
       tags:
         - "post"
 
-  /graphql/{{queryId}}/UnfavoriteTweet:
+  /graphql/{queryId}/UnfavoriteTweet:
     post:
       operationId: postUnfavoriteTweet
       description: unfavorite Tweet
+      parameters:
+        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation
@@ -32,10 +36,12 @@ paths:
       tags:
         - "post"
 
-  /graphql/{{queryId}}/CreateRetweet:
+  /graphql/{queryId}/CreateRetweet:
     post:
       operationId: postCreateRetweet
       description: create Retweet
+      parameters:
+        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation
@@ -46,10 +52,12 @@ paths:
       tags:
         - "post"
 
-  /graphql/{{queryId}}/DeleteRetweet:
+  /graphql/{queryId}/DeleteRetweet:
     post:
       operationId: postDeleteRetweet
       description: delete Retweet
+      parameters:
+        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation
@@ -60,10 +68,12 @@ paths:
       tags:
         - "post"
 
-  /graphql/{{queryId}}/CreateTweet:
+  /graphql/{queryId}/CreateTweet:
     post:
       operationId: postCreateTweet
       description: create Tweet
+      parameters:
+        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation
@@ -74,10 +84,12 @@ paths:
       tags:
         - "post"
 
-  /graphql/{{queryId}}/DeleteTweet:
+  /graphql/{queryId}/DeleteTweet:
     post:
       operationId: postDeleteTweet
       description: delete Retweet
+      parameters:
+        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation

--- a/src/openapi/paths/profile.yaml
+++ b/src/openapi/paths/profile.yaml
@@ -4,10 +4,12 @@ info:
   version: 0.0.1
 
 paths:
-  /graphql/{{queryId}}/ProfileSpotlightsQuery:
+  /graphql/{queryId}/ProfileSpotlightsQuery:
     get:
       operationId: getProfileSpotlightsQuery
       description: "get user by screen name"
+      parameters:
+        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation

--- a/src/openapi/paths/timeline.yaml
+++ b/src/openapi/paths/timeline.yaml
@@ -4,10 +4,12 @@ info:
   version: 0.0.1
 
 paths:
-  /graphql/{{queryId}}/HomeTimeline:
+  /graphql/{queryId}/HomeTimeline:
     get:
       operationId: getHomeTimeline
       description: get tweet list of timeline
+      parameters:
+        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation
@@ -18,10 +20,12 @@ paths:
       tags:
         - "tweet"
 
-  /graphql/{{queryId}}/HomeLatestTimeline:
+  /graphql/{queryId}/HomeLatestTimeline:
     get:
       operationId: getHomeLatestTimeline
       description: get tweet list of timeline
+      parameters:
+        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation
@@ -32,10 +36,12 @@ paths:
       tags:
         - "tweet"
 
-  /graphql/{{queryId}}/ListLatestTweetsTimeline:
+  /graphql/{queryId}/ListLatestTweetsTimeline:
     get:
       operationId: getListLatestTweetsTimeline
       description: get tweet list of timeline
+      parameters:
+        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation

--- a/src/openapi/paths/tweet.yaml
+++ b/src/openapi/paths/tweet.yaml
@@ -4,10 +4,12 @@ info:
   version: 0.0.1
 
 paths:
-  /graphql/{{queryId}}/TweetDetail:
+  /graphql/{queryId}/TweetDetail:
     get:
       operationId: getTweetDetail
       description: get TweetDetail
+      parameters:
+        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation

--- a/src/openapi/paths/user.yaml
+++ b/src/openapi/paths/user.yaml
@@ -4,10 +4,12 @@ info:
   version: 0.0.1
 
 paths:
-  /graphql/{{queryId}}/UserByScreenName:
+  /graphql/{queryId}/UserByScreenName:
     get:
       operationId: getUserByScreenName
       description: "get user by screen name"
+      parameters:
+        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation

--- a/src/openapi/paths/usertweets.yaml
+++ b/src/openapi/paths/usertweets.yaml
@@ -4,10 +4,12 @@ info:
   version: 0.0.1
 
 paths:
-  /graphql/{{queryId}}/UserTweets:
+  /graphql/{queryId}/UserTweets:
     get:
       operationId: getUserTweets
       description: "get user tweets"
+      parameters:
+        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation
@@ -18,10 +20,12 @@ paths:
       tags:
         - "tweet"
 
-  /graphql/{{queryId}}/UserTweetsAndReplies:
+  /graphql/{queryId}/UserTweetsAndReplies:
     get:
       operationId: getUserTweetsAndReplies
       description: "get user replies tweets"
+      parameters:
+        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation
@@ -32,10 +36,12 @@ paths:
       tags:
         - "tweet"
 
-  /graphql/{{queryId}}/UserMedia:
+  /graphql/{queryId}/UserMedia:
     get:
       operationId: getUserMedia
       description: "get user media tweets"
+      parameters:
+        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation
@@ -46,10 +52,12 @@ paths:
       tags:
         - "tweet"
 
-  /graphql/{{queryId}}/Likes:
+  /graphql/{queryId}/Likes:
     get:
       operationId: getLikes
       description: "get user likes tweets"
+      parameters:
+        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation

--- a/src/openapi/resources/parameters.yaml
+++ b/src/openapi/resources/parameters.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.3
+paths: {}
+
+components:
+  parameters:
+    queryId:
+        name: queryId
+        in: path
+        required: true
+        schema:
+          type: string

--- a/tools/build_config.py
+++ b/tools/build_config.py
@@ -13,7 +13,6 @@ class Config:
                 "other":[],
                 "request": {
                     key: [
-                        ReplaceQueryIdPlaceholder(split=-1),
                         SetResponsesHeader(suffix=None),
                         AddParametersOnContent(
                             split=-1, contentType="application/json"
@@ -23,7 +22,6 @@ class Config:
                 }
                 | {
                     key: [
-                        ReplaceQueryIdPlaceholder(split=-1),
                         SetResponsesHeader(suffix=None),
                         AddParametersOnParameters(
                             split=-1,
@@ -61,7 +59,6 @@ class Config:
                 "other":[],
                 "request": {
                     key: [
-                        ReplaceQueryIdPlaceholder(split=-1),
                         AddSecuritySchemesOnHeader(split=-1),
                         SetResponsesHeader(suffix=None),
                         AddParametersOnParameters(
@@ -73,7 +70,6 @@ class Config:
                 }
                 | {
                     key: [
-                        ReplaceQueryIdPlaceholder(split=-1),
                         AddSecuritySchemesOnHeader(split=-1),
                         SetResponsesHeader(suffix=None),
                         AddParametersOnBody(
@@ -115,7 +111,6 @@ class Config:
                 "other":[],
                 "request": {
                     key: [
-                        ReplaceQueryIdPlaceholder(split=-1),
                         SetResponsesHeader(suffix=None),
                         AddParametersOnParameters(
                             split=-1,
@@ -126,7 +121,6 @@ class Config:
                 }
                 | {
                     key: [
-                        ReplaceQueryIdPlaceholder(split=-1),
                         SetResponsesHeader(suffix=None),
                         AddParametersOnBody(
                             split=-1,
@@ -165,7 +159,6 @@ class Config:
                 "other":[],
                 "request": {
                     key: [
-                        ReplaceQueryIdPlaceholder(split=-1),
                         SetResponsesHeader(suffix=None),
                         AddParametersOnParameters(
                             split=-1,
@@ -176,7 +169,6 @@ class Config:
                 }
                 | {
                     key: [
-                        ReplaceQueryIdPlaceholder(split=-1),
                         SetResponsesHeader(suffix=None),
                         AddParametersOnParameters(
                             split=-1,

--- a/tools/hooks.py
+++ b/tools/hooks.py
@@ -118,14 +118,6 @@ class AddSecuritySchemesOnHeader(RequestHookBase):
         value["parameters"].extend(param)
         return path, value
 
-
-class ReplaceQueryIdPlaceholder(RequestHookBase):
-    def hook(self, path: str, value: dict):
-        path, value = super().hook(path, value)
-        new = self.PLACEHOLDER[self.path_name]["queryId"]
-        return path.replace(r"{{queryId}}", new), value
-
-
 class SetResponsesHeader(RequestHookBase):
     suffix: str
 


### PR DESCRIPTION
Currently the queryId in paths is statically replaced but that doesn't work because Twitter keeps changing the queryId for each different query. This PR changes this mechanism by using OpenAPI parameters allowing `queryId` substitution. Since the substitution schema for `queryId` is same in all cases, I have stored it in `resources/parameters.yaml`. Let me know if there's a better place for that.