### PR TITLE
Static generation of default values by the AddPathQueryIdOnParameters hook

### DIFF
--- a/src/openapi/paths/bookmarks.yaml
+++ b/src/openapi/paths/bookmarks.yaml
@@ -4,12 +4,10 @@ info:
   version: 0.0.1
 
 paths:
-  /graphql/{queryId}/Bookmarks:
+  /graphql/{pathQueryId}/Bookmarks:
     get:
       operationId: getBookmarks
       description: get bookmarks
-      parameters:
-        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation

--- a/src/openapi/paths/follow.yaml
+++ b/src/openapi/paths/follow.yaml
@@ -4,12 +4,10 @@ info:
   version: 0.0.1
 
 paths:
-  /graphql/{queryId}/Following:
+  /graphql/{pathQueryId}/Following:
     get:
       operationId: getFollowing
       description: get user list of following
-      parameters:
-        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation
@@ -20,12 +18,10 @@ paths:
       tags:
         - "user-list"
 
-  /graphql/{queryId}/Followers:
+  /graphql/{pathQueryId}/Followers:
     get:
       operationId: getFollowers
       description: get user list of followers
-      parameters:
-        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation

--- a/src/openapi/paths/post.yaml
+++ b/src/openapi/paths/post.yaml
@@ -4,12 +4,10 @@ info:
   version: 0.0.1
 
 paths:
-  /graphql/{queryId}/FavoriteTweet:
+  /graphql/{pathQueryId}/FavoriteTweet:
     post:
       operationId: postFavoriteTweet
       description: favorite Tweet
-      parameters:
-        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation
@@ -20,12 +18,10 @@ paths:
       tags:
         - "post"
 
-  /graphql/{queryId}/UnfavoriteTweet:
+  /graphql/{pathQueryId}/UnfavoriteTweet:
     post:
       operationId: postUnfavoriteTweet
       description: unfavorite Tweet
-      parameters:
-        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation
@@ -36,12 +32,10 @@ paths:
       tags:
         - "post"
 
-  /graphql/{queryId}/CreateRetweet:
+  /graphql/{pathQueryId}/CreateRetweet:
     post:
       operationId: postCreateRetweet
       description: create Retweet
-      parameters:
-        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation
@@ -52,12 +46,10 @@ paths:
       tags:
         - "post"
 
-  /graphql/{queryId}/DeleteRetweet:
+  /graphql/{pathQueryId}/DeleteRetweet:
     post:
       operationId: postDeleteRetweet
       description: delete Retweet
-      parameters:
-        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation
@@ -68,12 +60,10 @@ paths:
       tags:
         - "post"
 
-  /graphql/{queryId}/CreateTweet:
+  /graphql/{pathQueryId}/CreateTweet:
     post:
       operationId: postCreateTweet
       description: create Tweet
-      parameters:
-        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation
@@ -84,12 +74,10 @@ paths:
       tags:
         - "post"
 
-  /graphql/{queryId}/DeleteTweet:
+  /graphql/{pathQueryId}/DeleteTweet:
     post:
       operationId: postDeleteTweet
       description: delete Retweet
-      parameters:
-        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation

--- a/src/openapi/paths/profile.yaml
+++ b/src/openapi/paths/profile.yaml
@@ -4,12 +4,10 @@ info:
   version: 0.0.1
 
 paths:
-  /graphql/{queryId}/ProfileSpotlightsQuery:
+  /graphql/{pathQueryId}/ProfileSpotlightsQuery:
     get:
       operationId: getProfileSpotlightsQuery
       description: "get user by screen name"
-      parameters:
-        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation

--- a/src/openapi/paths/timeline.yaml
+++ b/src/openapi/paths/timeline.yaml
@@ -4,12 +4,10 @@ info:
   version: 0.0.1
 
 paths:
-  /graphql/{queryId}/HomeTimeline:
+  /graphql/{pathQueryId}/HomeTimeline:
     get:
       operationId: getHomeTimeline
       description: get tweet list of timeline
-      parameters:
-        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation
@@ -20,12 +18,10 @@ paths:
       tags:
         - "tweet"
 
-  /graphql/{queryId}/HomeLatestTimeline:
+  /graphql/{pathQueryId}/HomeLatestTimeline:
     get:
       operationId: getHomeLatestTimeline
       description: get tweet list of timeline
-      parameters:
-        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation
@@ -36,12 +32,10 @@ paths:
       tags:
         - "tweet"
 
-  /graphql/{queryId}/ListLatestTweetsTimeline:
+  /graphql/{pathQueryId}/ListLatestTweetsTimeline:
     get:
       operationId: getListLatestTweetsTimeline
       description: get tweet list of timeline
-      parameters:
-        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation

--- a/src/openapi/paths/tweet.yaml
+++ b/src/openapi/paths/tweet.yaml
@@ -4,12 +4,10 @@ info:
   version: 0.0.1
 
 paths:
-  /graphql/{queryId}/TweetDetail:
+  /graphql/{pathQueryId}/TweetDetail:
     get:
       operationId: getTweetDetail
       description: get TweetDetail
-      parameters:
-        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation

--- a/src/openapi/paths/user.yaml
+++ b/src/openapi/paths/user.yaml
@@ -4,12 +4,10 @@ info:
   version: 0.0.1
 
 paths:
-  /graphql/{queryId}/UserByScreenName:
+  /graphql/{pathQueryId}/UserByScreenName:
     get:
       operationId: getUserByScreenName
       description: "get user by screen name"
-      parameters:
-        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation

--- a/src/openapi/paths/usertweets.yaml
+++ b/src/openapi/paths/usertweets.yaml
@@ -4,12 +4,10 @@ info:
   version: 0.0.1
 
 paths:
-  /graphql/{queryId}/UserTweets:
+  /graphql/{pathQueryId}/UserTweets:
     get:
       operationId: getUserTweets
       description: "get user tweets"
-      parameters:
-        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation
@@ -20,12 +18,10 @@ paths:
       tags:
         - "tweet"
 
-  /graphql/{queryId}/UserTweetsAndReplies:
+  /graphql/{pathQueryId}/UserTweetsAndReplies:
     get:
       operationId: getUserTweetsAndReplies
       description: "get user replies tweets"
-      parameters:
-        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation
@@ -36,12 +32,10 @@ paths:
       tags:
         - "tweet"
 
-  /graphql/{queryId}/UserMedia:
+  /graphql/{pathQueryId}/UserMedia:
     get:
       operationId: getUserMedia
       description: "get user media tweets"
-      parameters:
-        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation
@@ -52,12 +46,10 @@ paths:
       tags:
         - "tweet"
 
-  /graphql/{queryId}/Likes:
+  /graphql/{pathQueryId}/Likes:
     get:
       operationId: getLikes
       description: "get user likes tweets"
-      parameters:
-        - $ref: "../resources/parameters.yaml#/components/parameters/queryId"
       responses:
         "200":
           description: Successful operation

--- a/src/openapi/resources/parameters.yaml
+++ b/src/openapi/resources/parameters.yaml
@@ -1,11 +1,15 @@
 openapi: 3.0.3
+info:
+  title: Twitter OpenAPI
+  version: 0.0.1
+
 paths: {}
 
 components:
   parameters:
     queryId:
-        name: queryId
-        in: path
-        required: true
-        schema:
-          type: string
+      name: queryId
+      in: path
+      required: true
+      schema:
+        type: string

--- a/src/openapi/schemas/tweet.yaml
+++ b/src/openapi/schemas/tweet.yaml
@@ -56,7 +56,8 @@ components:
         card:
           type: object
           properties:
-            rest_id: string
+            rest_id:
+              type: string
             legacy:
               type: object
               required:
@@ -64,7 +65,7 @@ components:
                 - "name"
                 - "url"
               properties:
-                name: 
+                name:
                   type: string
                 url:
                   type: string

--- a/tools/build_config.py
+++ b/tools/build_config.py
@@ -10,10 +10,11 @@ class Config:
             "docs": {
                 "openapi": [AddSecuritySchemesOnSecuritySchemes()],
                 "schemas": [],
-                "other":[],
+                "other": [],
                 "request": {
                     key: [
                         SetResponsesHeader(suffix=None),
+                        AddPathQueryIdOnParameters(split=-1),
                         AddParametersOnContent(
                             split=-1, contentType="application/json"
                         ),
@@ -23,6 +24,7 @@ class Config:
                 | {
                     key: [
                         SetResponsesHeader(suffix=None),
+                        AddPathQueryIdOnParameters(split=-1),
                         AddParametersOnParameters(
                             split=-1,
                             schemaType=None,
@@ -56,11 +58,12 @@ class Config:
             "dart": {
                 "openapi": [],
                 "schemas": [],
-                "other":[],
+                "other": [],
                 "request": {
                     key: [
                         AddSecuritySchemesOnHeader(split=-1),
                         SetResponsesHeader(suffix=None),
+                        AddPathQueryIdOnParameters(split=-1),
                         AddParametersOnParameters(
                             split=-1,
                             schemaType="string",
@@ -72,6 +75,7 @@ class Config:
                     key: [
                         AddSecuritySchemesOnHeader(split=-1),
                         SetResponsesHeader(suffix=None),
+                        AddPathQueryIdOnParameters(split=-1),
                         AddParametersOnBody(
                             split=-1,
                             schemaType=None,
@@ -108,10 +112,11 @@ class Config:
             "typescript": {
                 "openapi": [AddSecuritySchemesOnSecuritySchemes()],
                 "schemas": [],
-                "other":[],
+                "other": [],
                 "request": {
                     key: [
                         SetResponsesHeader(suffix=None),
+                        AddPathQueryIdOnParameters(split=-1),
                         AddParametersOnParameters(
                             split=-1,
                             schemaType="string",
@@ -122,6 +127,7 @@ class Config:
                 | {
                     key: [
                         SetResponsesHeader(suffix=None),
+                        AddPathQueryIdOnParameters(split=-1),
                         AddParametersOnBody(
                             split=-1,
                             schemaType=None,
@@ -156,10 +162,11 @@ class Config:
             "test": {
                 "openapi": [AddSecuritySchemesOnSecuritySchemes()],
                 "schemas": [],
-                "other":[],
+                "other": [],
                 "request": {
                     key: [
                         SetResponsesHeader(suffix=None),
+                        AddPathQueryIdOnParameters(split=-1),
                         AddParametersOnParameters(
                             split=-1,
                             schemaType="string",
@@ -170,6 +177,7 @@ class Config:
                 | {
                     key: [
                         SetResponsesHeader(suffix=None),
+                        AddPathQueryIdOnParameters(split=-1),
                         AddParametersOnParameters(
                             split=-1,
                             schemaType="string",


### PR DESCRIPTION
dist example
```yaml
  /graphql/{pathQueryId}/Bookmarks:
    get:
      description: get bookmarks
      operationId: getBookmarks
      parameters:
      - in: path
        name: pathQueryId
        required: true
        schema:
          default: tmd4ifV8RHltzn8ymGg1aw
          example: tmd4ifV8RHltzn8ymGg1aw
          type: string
```