### PR TITLE
add schema for self_thread in tweets

### DIFF
--- a/src/openapi/schemas/tweet.yaml
+++ b/src/openapi/schemas/tweet.yaml
@@ -200,6 +200,14 @@ components:
         id_str:
           type: string
           pattern: "^[0-9]+$"
+        self_thread:
+          type: object
+          required:
+            - "id_str"
+          properties:
+            id_str:
+              type: string
+              pattern: "^[0-9]+$"
         extended_entities:
           $ref: "#/components/schemas/ExtendedEntities"
 


### PR DESCRIPTION
`self_thread` is used by Twitter to identify tweets that are part of a thread. It is an object that contains a Snowflake ID of the topmost tweet. Since this property is only present in tweets that are part of a thread, it is a good way to detect & find threads.

The real problem is that Twitter doesn't always show a user's tweet in a chronological order. Sometimes whole tweets get hidden behind their "Show thread" button. With this change, we get the ability to also detect tweets that have hidden parents/children.