### PR TITLE
Mark discriminator properties of oneOf types mandatory.

### DIFF
--- a/dist/compatible/schemas/content.yaml
+++ b/dist/compatible/schemas/content.yaml
@@ -94,6 +94,8 @@ components:
       - __typename
       - cursorType
       - value
+      - entryType
+      - itemType
     TimelineTimelineItem:
       properties:
         __typename:

--- a/dist/compatible/schemas/tweet.yaml
+++ b/dist/compatible/schemas/tweet.yaml
@@ -186,6 +186,7 @@ components:
       - is_translatable
       - legacy
       - views
+      - __typename
     TweetLegacy:
       properties:
         bookmark_count:
@@ -267,6 +268,8 @@ components:
       properties:
         __typename:
           $ref: ./typename.yaml#/components/schemas/TypeName
+      required:
+      - __typename
     TweetUnion:
       discriminator:
         mapping":

--- a/dist/docs/schemas/content.yaml
+++ b/dist/docs/schemas/content.yaml
@@ -94,6 +94,8 @@ components:
       - __typename
       - cursorType
       - value
+      - entryType
+      - itemType
     TimelineTimelineItem:
       properties:
         __typename:

--- a/dist/docs/schemas/tweet.yaml
+++ b/dist/docs/schemas/tweet.yaml
@@ -186,6 +186,7 @@ components:
       - is_translatable
       - legacy
       - views
+      - __typename
     TweetLegacy:
       properties:
         bookmark_count:
@@ -267,6 +268,8 @@ components:
       properties:
         __typename:
           $ref: ./typename.yaml#/components/schemas/TypeName
+      required:
+      - __typename
     TweetUnion:
       discriminator:
         mapping":

--- a/src/openapi/schemas/content.yaml
+++ b/src/openapi/schemas/content.yaml
@@ -73,6 +73,8 @@ components:
         - "__typename"
         - "cursorType"
         - "value"
+        - "entryType"
+        - "itemType"
       properties:
         __typename:
           $ref: "./typename.yaml#/components/schemas/TypeName" # TimelineTimelineCursor

--- a/src/openapi/schemas/tweet.yaml
+++ b/src/openapi/schemas/tweet.yaml
@@ -34,6 +34,8 @@ components:
         __typename:
           $ref: "./typename.yaml#/components/schemas/TypeName" # TweetWithVisibilityResults
         # todo
+      required:
+        - "__typename"
 
     Tweet:
       required:
@@ -44,6 +46,7 @@ components:
         - "is_translatable"
         - "legacy"
         - "views"
+        - "__typename"
 
       properties:
         __typename:


### PR DESCRIPTION
Since they are used as a discriminator, it doesn't make sense for the field to be required and they do seem to be always present in practice. This also sidesteps a bug in https://github.com/deepmap/oapi-codegen, which generates invalid code if the field is optional.